### PR TITLE
Add Onsite/Virtual/Hybrid options

### DIFF
--- a/boost/boost.php
+++ b/boost/boost.php
@@ -4,7 +4,7 @@
  */
 
 $proper_name  = 'Experiential Learning Inventory';
-$version      = '0.3.4';
+$version      = '0.3.5';
 $register     = false;
 $unregister   = false;
 $import_sql   = true;

--- a/boost/install.sql
+++ b/boost/install.sql
@@ -662,6 +662,7 @@ CREATE TABLE intern_internship (
        middle_name_meta character varying,
        last_name_meta character varying,
 
+       location_type character varying NULL,
        loc_address character varying NULL,
        loc_city character varying NULL,
        loc_state character varying NULL,

--- a/boost/updates/update_00.03.05.sql
+++ b/boost/updates/update_00.03.05.sql
@@ -1,0 +1,1 @@
+alter table intern_internship add column location_type character varying;

--- a/class/Command/AddInternship.php
+++ b/class/Command/AddInternship.php
@@ -16,6 +16,7 @@
  * along with Internship Inventory.  If not, see <http://www.gnu.org/licenses/>.
  *
  * Copyright 2011-2018 Appalachian State University
+ * Copyright 2021 Brown Book Software
  */
 
 namespace Intern\Command;
@@ -36,7 +37,7 @@ use Intern\DatabaseStorage;
  * Controller class for creating an new internship.
  *
  * @author Jeremy Booker
- * @package hms
+ * @package intern
  */
 class AddInternship {
 

--- a/class/Command/SaveInternship.php
+++ b/class/Command/SaveInternship.php
@@ -17,6 +17,7 @@
  * along with Internship Inventory.  If not, see <http://www.gnu.org/licenses/>.
  *
  * Copyright 2011-2018 Appalachian State University
+ * Copyright 2021 Brown Book Software
  */
 
 namespace Intern\Command;
@@ -216,6 +217,7 @@ class SaveInternship
         }
 
         // Address, city, zip are always set (no matter domestic or international)
+        $i->location_type = $_POST['location_type'];
         $i->loc_address = self::trimField(strip_tags($_POST['loc_address']));
         $i->loc_city = self::trimField(strip_tags($_POST['loc_city']));
         $i->loc_zip = strip_tags($_POST['loc_zip']);

--- a/class/EditInternshipFormView.php
+++ b/class/EditInternshipFormView.php
@@ -16,6 +16,7 @@
  * along with Internship Inventory.  If not, see <http://www.gnu.org/licenses/>.
  *
  * Copyright 2011-2018 Appalachian State University
+ * Copyright 2021 Brown Book Software
  */
 
 namespace Intern;
@@ -412,6 +413,20 @@ class EditInternshipFormView {
             $this->tpl['LOCATION'] = 'International';
             $this->form->addHidden('location', 'international');
         }
+
+        // Location type
+        $locationType = $this->intern->getLocationType();
+        if($locationType == 'onsite') {
+            $this->tpl['ONSITE_ACTIVE'] = 'active';
+            $this->tpl['ONSITE_CHECKED'] = 'checked';
+        } else if ($locationType == 'virtual'){
+            $this->tpl['VIRTUAL_ACTIVE'] = 'active';
+            $this->tpl['VIRTUAL_CHECKED'] = 'checked';
+        } else if ($locationType == 'hybrid'){
+            $this->tpl['HYBRID_ACTIVE'] = 'active';
+            $this->tpl['HYBRID_CHECKED'] = 'checked';
+        }
+
 
         // Domestic fields
         $this->form->addText('loc_address');

--- a/class/Internship.php
+++ b/class/Internship.php
@@ -95,6 +95,7 @@ class Internship {
     public $domestic;
     public $international;
 
+    public $location_type; // on-site, virtual, hybrid
     public $loc_address;
     public $loc_city;
     public $loc_state;
@@ -155,6 +156,7 @@ class Internship {
         $this->term = $term;
 
         // Set basic location data
+        $this->setLocationType('onsite'); // Default to onsite location
         if($location == 'domestic') {
             $this->setDomestic(true);
             $this->setInternational(false);
@@ -362,6 +364,7 @@ class Internship {
         // Internship location data
         $csv['Domestic']               = $this->isDomestic() ? 'Yes' : 'No';
         $csv['International']          = $this->isInternational() ? 'Yes' : 'No';
+        $csv['Location Type']          = $this->getLocationType();
         $csv['Location Address']       = $this->loc_address;
         $csv['Location City']          = $this->loc_city;
         $csv['Location State']         = $this->loc_state;
@@ -684,6 +687,15 @@ class Internship {
     public function getLocationProvince()
     {
         return $this->loc_province;
+    }
+
+    public function getLocationType() {
+        return $this->location_type;
+    }
+
+    // Sets the location type. Should be one of: 'onsite', 'virtual', 'hybrid'
+    public function setLocationType($type) {
+        $this->location_type = $type;
     }
 
     public function isOiedCertified()

--- a/templates/internshipView.tpl
+++ b/templates/internshipView.tpl
@@ -232,6 +232,23 @@
       </fieldset>
 
       <div class="form-group">
+        <div class="btn-group col-lg-6 col-lg-push-3" role="group" aria-label="Location Options" data-toggle="buttons">
+          <!-- <button type="button" class="btn btn-default">On-Site</button>
+          <button type="button" class="btn btn-default">Virtual</button>
+          <button type="button" class="btn btn-default">Hybrid</button> -->
+          <label class="btn btn-default {ONSITE_ACTIVE}">On-site
+            <input type="radio" name="location_type" value="onsite" {ONSITE_CHECKED}>
+          </label>
+          <label class="btn btn-default {VIRTUAL_ACTIVE}">Virtual
+            <input type="radio" name="location_type" value="virtual" {VIRTUAL_CHECKED}>
+          </label>
+          <label class="btn btn-default {HYBRID_ACTIVE}">Hybrid
+            <input type="radio" name="location_type" value="hybrid" {HYBRID_CHECKED}>
+          </label>
+        </div>
+      </div>
+
+      <div class="form-group">
         <label class="col-lg-3 control-label" for="{LOC_ADDRESS_ID}">{LOC_ADDRESS_LABEL_TEXT}</label>
         <div class="col-lg-6">{LOC_ADDRESS}</div>
       </div>


### PR DESCRIPTION
Add location type field on Internship objects with 'onsite', 'virtual', and 'hybrid' options. Default on Internship creation is 'onsite'. Add to CSV export. Bump verison to 0.3.05 for DB schema update.