### PR TITLE
Check for a false student level code

### DIFF
--- a/class/InternshipView.php
+++ b/class/InternshipView.php
@@ -162,7 +162,9 @@ class InternshipView {
         // Show warning if the student's level does not exist
         $level = $this->intern->getLevel();
         $code = LevelFactory::getLevelObjectById($level);
-        if($code->getLevel() == 'Unknown')
+
+        // $code can be false if the level code doesn't exist in intern_student_level.
+        if($code !== false && $code->getLevel() == 'Unknown')
         {
             \NQ::simple('intern', UI\NotifyUI::WARNING, "This student's level of {$code->getCode()} did not exist. It was created and set to Unknown. Please ask an administrator for help.");
         }


### PR DESCRIPTION
Check for a false student level code that can happen when the level hasn't created in ELI's level table.